### PR TITLE
✨ Add Github organization support 

### DIFF
--- a/.cspell/words.txt
+++ b/.cspell/words.txt
@@ -2,9 +2,10 @@ commitlint
 Deville
 fakegroupname
 fakename
+fakeorganizationname
 fakeprojectname
-fakeusername
 fakerepositoryname
+fakeusername
 FAKEVALUE
 Framagit
 gitmoji

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
+import * as organization from "./organization";
 import * as provider from "./provider";
 import * as pulumi from "@pulumi/pulumi";
 import * as repository from "./repository";
+import type {
+    OrganizationPulumiConfig,
+    OrganizationsPulumiInfo
+} from "./organization";
 import type {
     ProvidersDict,
     ProvidersPulumiConfig
@@ -20,6 +25,12 @@ function deploy (): ProvidersDict {
 
     const providers = provider.initProvider(
         config.requireObject<ProvidersPulumiConfig>("githubProviders")
+    );
+
+    organization.initOrganization(
+        providers,
+        config.getObject<OrganizationsPulumiInfo>("githubOrganizations"),
+        config.getObject<OrganizationPulumiConfig>("githubOrganizationConfigs")
     );
 
     repository.initRepository(

--- a/src/organization/github.ts
+++ b/src/organization/github.ts
@@ -1,0 +1,54 @@
+import * as github from "@pulumi/github";
+// import type * as project from "../project";
+import * as pulumi from "@pulumi/pulumi";
+
+export interface IGithubOrganizationArgs {
+    settings: github.OrganizationSettingsArgs;
+}
+
+export interface IGithubOrganization {
+    name: string;
+    settings: github.OrganizationSettings;
+}
+
+/**
+ * Pulumi custom ComponentResource which deploy a github groups and associated
+ * resources such as labels, hooks, etc.
+ *
+ * @augments pulumi.ComponentResource
+ * @implements {IGithubOrganization} IGithubOrganization
+ */
+export class GithubOrganization extends pulumi.ComponentResource
+    implements IGithubOrganization {
+
+    public name: string;
+
+    public settings: github.OrganizationSettings;
+
+    /**
+     * Constructor of the ComponentResource GithubOrganization
+     *
+     * @param {string} name - Name of the organization
+     * @param {IGithubOrganizationArgs} args - This pulumi object arguments
+     * @param {pulumi.ComponentResourceOptions} [opts] - Pulumi resources
+     *      options
+     */
+    public constructor (
+        name: string,
+        args: IGithubOrganizationArgs,
+        opts?: pulumi.ComponentResourceOptions
+    ) {
+        super(`github-repo:group:${name}`, name, args, opts);
+        this.name = name;
+        this.settings = new github.OrganizationSettings(
+            name,
+            args.settings,
+            {
+                ...opts,
+                "parent": this
+            }
+        );
+        this.registerOutputs();
+    }
+
+}

--- a/src/organization/index.ts
+++ b/src/organization/index.ts
@@ -1,0 +1,3 @@
+export {GithubOrganization} from "./github";
+export * from "./types";
+export * from "./utils";

--- a/src/organization/types.ts
+++ b/src/organization/types.ts
@@ -1,0 +1,38 @@
+import type * as githubOrganization from "./github";
+import type * as pulumi from "@pulumi/pulumi";
+
+// Interface
+export interface OrganizationData {
+    args: githubOrganization.IGithubOrganizationArgs;
+    opts: pulumi.CustomResourceOptions;
+}
+
+export interface OrganizationInfo {
+    config?: string;
+    providers?: string[];
+    settings: ArgsDict;
+}
+
+export interface ArgsDict {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+}
+
+export interface OrganizationsPulumiInfo {
+    [key: string]: OrganizationInfo;
+}
+
+export interface OrganizationsDict {
+    [key: string]: githubOrganization.GithubOrganization;
+}
+
+export interface OrganizationPulumiConfig {
+    [key: string]: pulumi.Inputs | object;
+}
+
+// Enum
+export enum OrganizationType {
+    default = "default",
+    fork = "fork",
+    mirror = "mirror"
+}

--- a/src/organization/utils.ts
+++ b/src/organization/utils.ts
@@ -1,0 +1,184 @@
+import type * as github from "@pulumi/github";
+import * as pulumi from "@pulumi/pulumi";
+import type {
+    GithubProvider,
+    ProvidersDict
+} from "../provider";
+import type {
+    OrganizationData,
+    OrganizationInfo,
+    OrganizationPulumiConfig,
+    OrganizationsPulumiInfo
+} from "./types";
+import {
+    GithubOrganization
+} from "./index";
+import {
+    slugify
+} from "../utils";
+
+/**
+ * Compute organization configuration depending on the type of organization
+ *
+ * @param {string} providerName - Name of the gitProvider
+ * @param {OrganizationPulumiConfig} organizationConfig - Organization
+ *      configuration from the stack
+ * @param {string} [organizationType] - Type of the organization (default:
+ *      "default")
+ * @returns {github.OrganizationArgs} Set of organization args corresponding to
+ *      organization configuration
+ */
+function computeOrganizationConfig (
+    providerName: string,
+    organizationConfig?: OrganizationPulumiConfig,
+    organizationType = "default"
+): github.OrganizationSettingsArgs {
+    if (organizationConfig) {
+        const config: pulumi.Config = new pulumi.Config();
+
+        if (
+            typeof organizationConfig !== "undefined" &&
+            "default" in organizationConfig
+        ) {
+            // eslint-disable-next-line max-len
+            if (providerName === slugify(config.require("githubMainProvider")) &&
+                organizationType === "default"
+            ) {
+                return organizationConfig.default as
+                    github.OrganizationSettingsArgs;
+            }
+            return {
+                ...organizationConfig.default,
+                ...organizationConfig[organizationType]
+            } as github.OrganizationSettingsArgs;
+        }
+    }
+
+    return {} as github.OrganizationSettingsArgs;
+}
+
+/**
+ * Compute data, i.e. args and opts for the organization
+ *
+ * @param {GithubProvider} provider - Provider object
+ * @param {string} organizationName - Name of the organization
+ * @param {OrganizationInfo} organizationInfo - Info of the organization
+ *      organization configurations
+ * @param {OrganizationPulumiConfig} [organizationsConfig] - Possible
+ * @returns {OrganizationData} Object with args and data for Pulumi Organization
+ *      object
+ */
+function computeOrganizationData (
+    provider: GithubProvider,
+    organizationName: string,
+    organizationInfo?: OrganizationInfo,
+    organizationsConfig?: OrganizationPulumiConfig
+): OrganizationData {
+    return {
+        "args": {
+            "settings": {
+                ...computeOrganizationConfig(
+                    provider.name,
+                    organizationsConfig,
+                    organizationInfo?.config
+                ),
+                ...organizationInfo?.settings,
+                "name": organizationName
+            } as github.OrganizationSettingsArgs
+        },
+        "opts": {
+            "parent": provider.provider,
+            "provider": provider.provider
+        }
+    };
+}
+
+/**
+ * Create provider supported organization
+ *
+ * @param {GithubProvider} provider - Provider object
+ * @param {string} organizationName - Name of the organization
+ * @param {OrganizationInfo} organizationInfo - Info of the organization
+ * @param {OrganizationPulumiConfig} [organizationsConfig] - Possible
+ *      organization configurations
+ * @returns {GithubOrganization} Pulumi organization object depending on
+ *      provider
+ */
+function createOrganization (
+    provider: GithubProvider,
+    organizationName: string,
+    organizationInfo: OrganizationInfo,
+    organizationsConfig?: OrganizationPulumiConfig
+): GithubOrganization {
+    const data = computeOrganizationData(
+        provider, organizationName, organizationInfo, organizationsConfig
+    );
+    const currOrganization = new GithubOrganization(
+        `${slugify(organizationName)}`,
+        data.args,
+        data.opts
+    );
+
+
+    provider.organizations[organizationName] = currOrganization;
+    return currOrganization;
+}
+
+
+/**
+ * Process to the deployment of git organization for defined providers
+ *
+ * @param {ProvidersDict} providers - Set of providers
+ * @param {string} organizationName - Name of the organization
+ * @param {OrganizationInfo} organizationInfo - Information of the organization
+ *      (such as desc, etc.)
+ * @param {OrganizationPulumiConfig} [organizationsConfig] - organizationConfigs
+ *      set in the
+ */
+function processOrganizations (
+    providers: ProvidersDict,
+    organizationName: string,
+    organizationInfo: OrganizationInfo,
+    organizationsConfig?: OrganizationPulumiConfig
+): void {
+    if (organizationInfo.providers) {
+        for (const iProvider in providers) {
+            if (organizationInfo.providers.includes(iProvider)) {
+                createOrganization(
+                    providers[iProvider],
+                    organizationName,
+                    organizationInfo,
+                    organizationsConfig
+                );
+            }
+        }
+    }
+}
+
+/**
+ * Initialize the processing of each organizations defined in the stack
+ *
+ * @param {ProvidersDict} providers - Set of providers
+ * @param {OrganizationsPulumiInfo} [orgInfo] - organizations entries
+ *      set in the stack
+ * @param {OrganizationPulumiConfig} [orgConfig] - organizationsConfig
+ *      set in the stack
+ */
+export function initOrganization (
+    providers: ProvidersDict,
+    orgInfo?: OrganizationsPulumiInfo,
+    orgConfig?: OrganizationPulumiConfig
+): void {
+    if (orgInfo) {
+        for (const iOrg in orgInfo) {
+            if ("billingEmail" in orgInfo[iOrg].settings) {
+                processOrganizations(
+                    providers,
+                    iOrg,
+                    orgInfo[iOrg],
+                    orgConfig
+                );
+            }
+        }
+    }
+}

--- a/src/provider/github.ts
+++ b/src/provider/github.ts
@@ -1,4 +1,5 @@
 import * as github from "@pulumi/github";
+import type * as organization from "../organization";
 import * as pulumi from "@pulumi/pulumi";
 import type * as repositories from "../repository";
 import * as utils from "../utils";
@@ -10,6 +11,7 @@ export interface IGithubProvider {
     name: string;
     username: string;
     provider: github.Provider;
+    organizations: organization.OrganizationsDict;
     repositories: repositories.RepositoriesDict;
 }
 
@@ -28,6 +30,8 @@ export class GithubProvider extends pulumi.ComponentResource
     public username = "";
 
     public provider: github.Provider;
+
+    public organizations: organization.OrganizationsDict = {};
 
     public repositories: repositories.RepositoriesDict = {};
 

--- a/tests/organization/github.ts
+++ b/tests/organization/github.ts
@@ -1,0 +1,24 @@
+import * as github from "../../src/organization/github";
+import type * as pulumi from "@pulumi/pulumi";
+import test from "ava";
+
+const FAKE_NAME = "fakeName";
+const FAKE_EMAIL = "fakeName@fakeDomain.tld";
+
+test("Config organization", (currTest) => {
+    const args: github.IGithubOrganizationArgs = {
+        "settings": {
+            "billingEmail": FAKE_EMAIL
+        }
+    };
+    const opts: pulumi.CustomResourceOptions = {
+        "aliases": [{"name": FAKE_NAME}]
+    };
+    const githubOrganization = new github.GithubOrganization(
+        FAKE_NAME,
+        args,
+        opts
+    );
+
+    currTest.is(githubOrganization.name, FAKE_NAME);
+});

--- a/tests/organization/utils.ts
+++ b/tests/organization/utils.ts
@@ -1,0 +1,130 @@
+import * as organization from "../../src/organization";
+import * as provider from "../../src/provider";
+import test from "ava";
+
+// FAKE PROVIDER CONFIG
+const PROVIDER_CONFIG = {
+    "config": {
+        "baseUrl": "https://fake.github.tld",
+        "token": "fakeToken"
+    },
+    "username": "fakeUserName"
+};
+
+const PROVIDER_NAME = [
+    "fakeGithub1",
+    "fakeGithub2"
+];
+const [MAIN_PROVIDER] = PROVIDER_NAME;
+
+const PROVIDER: provider.ProvidersPulumiConfig = {
+    "fakeGithub1": PROVIDER_CONFIG,
+    "fakeGithub2": PROVIDER_CONFIG
+};
+
+const FAKE_EMAIL = "fakeName@fakeDomain.tld";
+
+const ENV: {[key: string]: string} = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    "PULUMI_CONFIG": `{ "project:githubMainProvider": "${MAIN_PROVIDER}" }`
+};
+
+Object.entries(ENV).forEach(([key, val]) => {
+    process.env[key] = val;
+});
+
+test(
+    "organization with supported provider with minimum organization args",
+    (currTest) => {
+        const fakeOrganizations: organization.OrganizationsPulumiInfo = {
+            "fakeOrganizationName": {
+                // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+                "providers": [PROVIDER_NAME[0]],
+                "settings": {
+                    "billingEmail": FAKE_EMAIL
+                }
+            }
+        };
+
+        const providers = provider.initProvider(PROVIDER);
+        organization.initOrganization(
+            providers,
+            fakeOrganizations
+        );
+
+        currTest.is(
+            // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+            providers[PROVIDER_NAME[0]].
+                organizations.fakeOrganizationName.name,
+            "fakeorganizationname"
+        );
+    }
+);
+
+test(
+    "organization with supported provider with organization default config",
+    (currTest) => {
+        const fakeOrganizations: organization.OrganizationsPulumiInfo = {
+            "fakeOrganizationName": {
+                // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+                "providers": [PROVIDER_NAME[0]],
+                "settings": {
+                    "billingEmail": FAKE_EMAIL
+                }
+            }
+        };
+
+        const fakeOrganizationConfig: organization.OrganizationPulumiConfig = {
+            "default": {}
+        };
+
+        const providers = provider.initProvider(PROVIDER);
+        organization.initOrganization(
+            providers,
+            fakeOrganizations,
+            fakeOrganizationConfig
+        );
+
+        currTest.is(
+            // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+            providers[PROVIDER_NAME[0]].
+                organizations.fakeOrganizationName.name,
+            "fakeorganizationname"
+        );
+    }
+);
+
+test(
+    "organization with supported provider with organization mirror config",
+    (currTest) => {
+        const fakeOrganizations: organization.OrganizationsPulumiInfo = {
+            "fakeOrganizationName": {
+                "config": "mirror",
+                // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+                "providers": [PROVIDER_NAME[0]],
+                "settings": {
+                    "billingEmail": FAKE_EMAIL
+                }
+            }
+        };
+
+        const fakeOrganizationConfig: organization.OrganizationPulumiConfig = {
+            "default": {},
+            "mirror": {}
+        };
+
+        const providers = provider.initProvider(PROVIDER);
+        organization.initOrganization(
+            providers,
+            fakeOrganizations,
+            fakeOrganizationConfig
+        );
+
+        currTest.is(
+            // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+            providers[PROVIDER_NAME[0]].
+                organizations.fakeOrganizationName.name,
+            "fakeorganizationname"
+        );
+    }
+);


### PR DESCRIPTION
Mainly support organization configuration as Github Organization is mainly considered as a User and most configuration are done at Repo level.

Does not support Action/Environnement related for now as I do not use it.